### PR TITLE
Add wait for PVC ready

### DIFF
--- a/perfkitbenchmarker/providers/kubernetes/kubernetes_disk.py
+++ b/perfkitbenchmarker/providers/kubernetes/kubernetes_disk.py
@@ -238,6 +238,24 @@ class CephDisk(KubernetesDisk):
 class PersistentVolumeClaim(resource.BaseResource):
   """Object representing a K8s PVC."""
 
+  @vm_util.Retry(poll_interval=10, max_retries=100, log_errors=False)
+  def _WaitForPVCBoundCompletion(self):
+    """
+    Need to wait for the PVC to get up  - PVC may take some time to be ready(Bound).
+    """
+    exists_cmd = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig, 'get',
+                  'pvc', '-o=json', self.name]
+    logging.info("Waiting for PVC %s" % self.name)
+    pvc_info, _, _ = vm_util.IssueCommand(exists_cmd, suppress_warning=True)
+    if pvc_info:
+      pvc_info = json.loads(pvc_info)
+      pvc = pvc_info['status']['phase']
+      if pvc == "Bound":
+        logging.info("PVC is ready.")
+        return
+    raise Exception("PVC %s is not ready. Retrying to check status." %
+                    self.name)
+
   def __init__(self, name, storage_class, size):
     super(PersistentVolumeClaim, self).__init__()
     self.name = name
@@ -248,6 +266,7 @@ class PersistentVolumeClaim(resource.BaseResource):
     """Creates the PVC."""
     body = self._BuildBody()
     kubernetes_helper.CreateResource(body)
+    self._WaitForPVCBoundCompletion()
 
   def _Delete(self):
     """Deletes the PVC."""
@@ -287,7 +306,6 @@ class StorageClass(resource.BaseResource):
   def _Create(self):
     """Creates the PVC."""
     body = self._BuildBody()
-    kubernetes_helper.CreateResource(body)
 
   def _Delete(self):
     """Deletes the PVC."""


### PR DESCRIPTION
before:
```2018-05-02 11:14:47,610 836faced Thread-2 copy_throughput(1/1) INFO     Running: /usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config create -f /tmp/tmpNM1OBC
2018-05-02 11:15:19,307 836faced Thread-2 copy_throughput(1/1) INFO     Ran: {/usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config create -f /tmp/tmpNM1OBC}  ReturnCode:1
STDOUT:
STDERR: Error from server (Timeout): error when creating "/tmp/tmpNM1OBC": Timeout: request did not complete within allowed duration

['/usr/local/bin/kubectl', '--kubeconfig=/k8s-custer-config/config', 'create', '-f', '/tmp/tmpNM1OBC']
stdout: , stderr:Error from server (Timeout): error when creating "/tmp/tmpNM1OBC": Timeout: request did not complete within allowed duration
, retcode:1
2018-05-02 11:15:19,308 836faced Thread-2 copy_throughput(1/1) INFO     Retrying exception running IssueRetryableCommand: Command returned a non-zero exit code.

2018-05-02 11:15:35,832 836faced Thread-2 copy_throughput(1/1) INFO     Running: /usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config create -f /tmp/tmpNM1OBC
2018-05-02 11:15:37,486 836faced Thread-2 copy_throughput(1/1) INFO     Ran: {/usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config create -f /tmp/tmpNM1OBC}  ReturnCode:1
STDOUT:
STDERR: Error from server (InternalError): error when creating "/tmp/tmpNM1OBC": Internal error occurred: admission webhook "sds-operator-webhook.certascale.io" denied the request: Pod is already created

['/usr/local/bin/kubectl', '--kubeconfig=/k8s-custer-config/config', 'create', '-f', '/tmp/tmpNM1OBC']
stdout: , stderr:Error from server (InternalError): error when creating "/tmp/tmpNM1OBC": Internal error occurred: admission webhook "sds-operator-webhook.certascale.io" denied the request: Pod is already created
, retcode:1
2018-05-02 11:15:37,487 836faced Thread-2 copy_throughput(1/1) INFO     Retrying exception running IssueRetryableCommand: Command returned a non-zero exit code.```



after:
```2018-05-02 11:32:36,398 39d4b965 Thread-2 copy_throughput(1/1) INFO     Waiting for PVC pkb-39d4b965-0-0
2018-05-02 11:32:36,398 39d4b965 Thread-2 copy_throughput(1/1) INFO     Running: /usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config get pvc -o=json pkb-39d4b965-0-0
2018-05-02 11:32:44,448 39d4b965 Thread-2 copy_throughput(1/1) INFO     Waiting for PVC pkb-39d4b965-0-0
2018-05-02 11:32:44,448 39d4b965 Thread-2 copy_throughput(1/1) INFO     Running: /usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config get pvc -o=json pkb-39d4b965-0-0
2018-05-02 11:32:54,207 39d4b965 Thread-2 copy_throughput(1/1) INFO     Waiting for PVC pkb-39d4b965-0-0
2018-05-02 11:32:54,207 39d4b965 Thread-2 copy_throughput(1/1) INFO     Running: /usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config get pvc -o=json pkb-39d4b965-0-0
2018-05-02 11:33:02,039 39d4b965 Thread-2 copy_throughput(1/1) INFO     Waiting for PVC pkb-39d4b965-0-0
2018-05-02 11:33:02,039 39d4b965 Thread-2 copy_throughput(1/1) INFO     Running: /usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config get pvc -o=json pkb-39d4b965-0-0
2018-05-02 11:33:11,396 39d4b965 Thread-2 copy_throughput(1/1) INFO     Waiting for PVC pkb-39d4b965-0-0
2018-05-02 11:33:11,397 39d4b965 Thread-2 copy_throughput(1/1) INFO     Running: /usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config get pvc -o=json pkb-39d4b965-0-0
2018-05-02 11:33:14,346 39d4b965 Thread-2 copy_throughput(1/1) INFO     PVC is ready.```