### PR TITLE
check StorageClass exists before creation

### DIFF
--- a/perfkitbenchmarker/providers/kubernetes/kubernetes_disk.py
+++ b/perfkitbenchmarker/providers/kubernetes/kubernetes_disk.py
@@ -303,9 +303,32 @@ class StorageClass(resource.BaseResource):
     self.provisioner = provisioner
     self.parameters = parameters
 
+  def _CheckStorageClassExists(self):
+    """
+    Prevent duplicated StorageClass creation If the StorageClass with the same name and parameters exists
+    :return: True or False
+    """
+
+    body = self._BuildBody()
+    exists_cmd = [FLAGS.kubectl, '--kubeconfig=%s' % FLAGS.kubeconfig, 'get',
+                  'sc', '-o=json', self.name]
+
+    sc_info, _, _ = vm_util.IssueCommand(exists_cmd, suppress_warning=True)
+    if sc_info:
+      sc_info = json.loads(sc_info)
+      sc_name = sc_info['metadata']['name']
+      if sc_name == self.name:
+        logging.info("StorageClass already exists.")
+        return True
+      else:
+        logging.info("About to create new StorageClass: {0}".format(self.name))
+        return False
+
   def _Create(self):
     """Creates the PVC."""
     body = self._BuildBody()
+    if not self._CheckStorageClassExists():
+      kubernetes_helper.CreateResource(body)
 
   def _Delete(self):
     """Deletes the PVC."""


### PR DESCRIPTION
Prevent duplicated StorageClass creation If the StorageClass with the same name and parameters exists


```'disk_type': 'persistentVolumeClaim', 'disk_size': 50, 'mount_point': '/scratch', 'parameters': {'clusterid': '82006289f2eb6243d78ce64283257464', 'resturl': 'https://sds-operator.default.svc.certascale.local:443', 'volumetype': 'none'}, 'provisioner': 'kubernetes.io/glusterfs'}
2018-05-02 11:14:43,909 836faced MainThread copy_throughput(1/1) INFO     Provisioning resources for benchmark copy_throughput
2018-05-02 11:14:43,910 836faced MainThread copy_throughput(1/1) INFO     No legacy->new disk type map for provider Kubernetes
================================================================================
['/usr/local/bin/kubectl', '--kubeconfig=/k8s-custer-config/config', 'create', '-f', '/tmp/tmpynYiJa']
['{"kind": "StorageClass", "provisioner": "kubernetes.io/glusterfs", "parameters": {"volumetype": "none", "resturl": "https://sds-operator.default.svc.certascale.local:443", "clusterid": "82006289f2eb6243d78ce64283257464"}, "apiVersion": "storage.k8s.io/v1", "metadata": {"name": "pkb-836faced-0"}}']
================================================================================
2018-05-02 11:14:43,919 836faced Thread-2 copy_throughput(1/1) INFO     Running: /usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config create -f /tmp/tmpynYiJa
['/usr/local/bin/kubectl', '--kubeconfig=/k8s-custer-config/config', 'create', '-f', '/tmp/tmpynYiJa']
stdout: storageclass.storage.k8s.io "pkb-836faced-0" created
, stderr:, retcode:0
================================================================================
['/usr/local/bin/kubectl', '--kubeconfig=/k8s-custer-config/config', 'create', '-f', '/tmp/tmpS3fVKR']
['{"kind": "PersistentVolumeClaim", "spec": {"storageClassName": "pkb-836faced-0", "accessModes": ["ReadWriteOnce"], "resources": {"requests": {"storage": "50Gi"}}}, "apiVersion": "v1", "metadata": {"name": "pkb-836faced-0-0"}}']
================================================================================
2018-05-02 11:14:45,658 836faced Thread-2 copy_throughput(1/1) INFO     Running: /usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config create -f /tmp/tmpS3fVKR
['/usr/local/bin/kubectl', '--kubeconfig=/k8s-custer-config/config', 'create', '-f', '/tmp/tmpS3fVKR']
stdout: persistentvolumeclaim "pkb-836faced-0-0" created
, stderr:, retcode:0
2018-05-02 11:14:47,608 836faced Thread-2 copy_throughput(1/1) INFO     About to create a pod with the following configuration:
2018-05-02 11:14:47,608 836faced Thread-2 copy_throughput(1/1) INFO     {"kind": "Pod", "spec": {"dnsPolicy": "ClusterFirst", "containers": [{"volumeMounts": [{"mountPath": "/scratch", "name": "pkb-836faced-0-0"}], "image": "quay.io/certa/perfkitbenchmarker-os-image:1.0", "securityContext": {"privileged": true}, "name": "pkb-836faced-0"}], "volumes": [{"name": "pkb-836faced-0-0", "persistentVolumeClaim": {"claimName": "pkb-836faced-0-0"}}]}, "apiVersion": "v1", "metadata": {"labels": {"pkb": "pkb-836faced-0"}, "name": "pkb-836faced-0"}}
================================================================================
['/usr/local/bin/kubectl', '--kubeconfig=/k8s-custer-config/config', 'create', '-f', '/tmp/tmpNM1OBC']
['{"kind": "Pod", "spec": {"dnsPolicy": "ClusterFirst", "containers": [{"volumeMounts": [{"mountPath": "/scratch", "name": "pkb-836faced-0-0"}], "image": "quay.io/certa/perfkitbenchmarker-os-image:1.0", "securityContext": {"privileged": true}, "name": "pkb-836faced-0"}], "volumes": [{"name": "pkb-836faced-0-0", "persistentVolumeClaim": {"claimName": "pkb-836faced-0-0"}}]}, "apiVersion": "v1", "metadata": {"labels": {"pkb": "pkb-836faced-0"}, "name": "pkb-836faced-0"}}']
================================================================================
2018-05-02 11:14:47,610 836faced Thread-2 copy_throughput(1/1) INFO     Running: /usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config create -f /tmp/tmpNM1OBC
2018-05-02 11:15:19,307 836faced Thread-2 copy_throughput(1/1) INFO     Ran: {/usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config create -f /tmp/tmpNM1OBC}  ReturnCode:1
STDOUT:
STDERR: Error from server (Timeout): error when creating "/tmp/tmpNM1OBC": Timeout: request did not complete within allowed duration

['/usr/local/bin/kubectl', '--kubeconfig=/k8s-custer-config/config', 'create', '-f', '/tmp/tmpNM1OBC']
stdout: , stderr:Error from server (Timeout): error when creating "/tmp/tmpNM1OBC": Timeout: request did not complete within allowed duration
, retcode:1
2018-05-02 11:15:19,308 836faced Thread-2 copy_throughput(1/1) INFO     Retrying exception running IssueRetryableCommand: Command returned a non-zero exit code.

2018-05-02 11:15:35,832 836faced Thread-2 copy_throughput(1/1) INFO     Running: /usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config create -f /tmp/tmpNM1OBC
2018-05-02 11:15:37,486 836faced Thread-2 copy_throughput(1/1) INFO     Ran: {/usr/local/bin/kubectl --kubeconfig=/k8s-custer-config/config create -f /tmp/tmpNM1OBC}  ReturnCode:1
STDOUT:
STDERR: Error from server (InternalError): error when creating "/tmp/tmpNM1OBC": Internal error occurred: admission webhook "sds-operator-webhook.certascale.io" denied the request: Pod is already created
```